### PR TITLE
adding window to flow options, creating intermmediate function for flow building

### DIFF
--- a/lib/exmld.ex
+++ b/lib/exmld.ex
@@ -161,14 +161,21 @@ defmodule Exmld do
     |> Flow.partition(key: partition_key,
                       stages: opts[:num_stages] || System.schedulers_online(),
                       min_demand: opts[:min_demand] || 1,
-                      max_demand: opts[:max_demand] || 500)
+                      max_demand: opts[:max_demand] || 500,
+                      window: opts[:window] || Flow.Window.global())
     |> Flow.reduce(state0, process_fn)
   end
 
-  def start_link(opts) do
+  @doc """
+  You can use this one to keep building your flow after calling flow/6 above.
+  """
+  def from_stages(opts) do
     Flow.from_stages(opts.stages)
     |> flow(opts.extract_items_fn, opts.partition_key,
             opts.state0, opts.process_fn, opts.flow_opts)
-    |> Flow.start_link()
+  end
+
+  def start_link(opts) do
+    from_stages(opts) |> Flow.start_link()
   end
 end


### PR DESCRIPTION
Two additions are proposed:

1. Add `window` to the flow options so one can use a custom [Flow.Window](https://hexdocs.pm/flow/Flow.Window.html)

2. `from_stages/1` is useful to do something like:

```elixir
    flow = Exmld.from_stages(flow_spec) |>
    Flow.emit(:state) |>
    Flow.map_state(fn(x, y, z) ->
      # .. do stuff ... 
    end)
```

Then one should call `Flow.start_link/1` directly instead of `Exmld.start_link/1`. The current `start_link/1` behavior is kept for b/c.
