### PR TITLE
lower log level for message

### DIFF
--- a/lib/exmld/kinesis_worker.ex
+++ b/lib/exmld/kinesis_worker.ex
@@ -317,7 +317,7 @@ defmodule Exmld.KinesisWorker do
   # pipeline can't keep up with the producer, so its parameters should be tuned.
   defp await_pending(%__MODULE__{await_sleep_interval: sleep_interval,
                                  pending: pending} = state) when map_size(pending) > 0 do
-    Logger.info("#{state.shard_id} awaiting #{inspect map_size(pending)} items...")
+    Logger.debug("#{state.shard_id} awaiting #{inspect map_size(pending)} items...")
     :timer.sleep(sleep_interval)
     state
     |> incr(:heartbeats, 1)


### PR DESCRIPTION
We already have https://github.com/AdRoll/exmld/blob/master/lib/exmld/kinesis_worker.ex#L176 and this message might appear often, so perhaps we can lower its priority. Thoughts?